### PR TITLE
Reduce the build time of LLVM artifacts in Debug mode

### DIFF
--- a/third-party/llvm/LLVMBuilder.zig
+++ b/third-party/llvm/LLVMBuilder.zig
@@ -35,6 +35,10 @@ const zlib = parent_build.zlib;
 
 pub const default_optimize: std.builtin.OptimizeMode = .ReleaseSafe;
 
+// Prioritize speed for modules compiled for the host to avoid slowing a debug build.
+// For example, a LLVMTableGen executable (compiled with Debug) increases the build time because the generation of .inc files is slower.
+const default_host_optimize = std.builtin.OptimizeMode.ReleaseFast;
+
 pub const Options = struct {
     optimize: ?std.builtin.OptimizeMode = null,
 };
@@ -567,7 +571,7 @@ fn buildTargetLLVM(self: *Self) void {
 fn createHostModule(self: *const Self) *std.Build.Module {
     return self.b.createModule(.{
         .target = self.b.graph.host,
-        .optimize = self.metadata.optimize,
+        .optimize = default_host_optimize,
         .link_libc = true,
         .link_libcpp = true,
     });
@@ -598,6 +602,7 @@ pub const ArtifactCreateConfig = struct {
     config_headers: ?[]const *std.Build.Step.ConfigHeader = null,
     link_libraries: ?[]const Artifact = null,
     target_override: ?std.Build.ResolvedTarget = null,
+    optimize_override: ?std.builtin.OptimizeMode = null,
     bundle_compiler_rt: ?bool = null,
 };
 
@@ -606,6 +611,9 @@ fn createLLVMModule(self: *const Self, config: ArtifactCreateConfig) *std.Build.
     const mod = self.createTargetModule();
     if (config.target_override) |target| {
         mod.resolved_target = target;
+    }
+    if (config.optimize_override) |optimize| {
+        mod.optimize = optimize;
     }
 
     if (config.cxx_source_files) |cxx_source_files| mod.addCSourceFiles(.{
@@ -1092,6 +1100,10 @@ fn buildDemangle(self: *const Self, platform: Platform) Artifact {
         },
         .target_override = switch (platform) {
             .host => self.b.graph.host,
+            .target => null,
+        },
+        .optimize_override = switch (platform) {
+            .host => default_host_optimize,
             .target => null,
         },
     });


### PR DESCRIPTION
## Description

8457c4a1395a2392f3c7df02339035c77309ecfe permits to generate Debug LLVM artifacts and should speed up debug builds, but I noticed that release builds are the faster ones.

After some analysis, the compilation of LLVM artifacts is faster without optimizations but the generation of .inc files done by `LLVMTableGen` takes more time because the executable is not optimized.

So this PR ensures that `LLVMTableGen` executable is always compiled with optimizations to avoid a slow .inc files generation.

## Additional Context:

### Build times

The following results were obtained by running `time /opt/zig/zig-x86_64-linux-0.16.0/zig build --summary all -Dtarget=x86_64-linux-gnu -j1` on a project installing all LLVM artifacts to `zig-out`. The `LLVMBuilder` of the project is initialized with `.{ .optimize = .Debug }`.

Before optimization passthrough (4941e73690d7dcaa91ac308fd3a3755e0f133a2e): [before.md](https://github.com/user-attachments/files/31615395/before.md)
After optimization passthrough (4de8ed6af21d9fe27937d0c9d93c109d252ac833): [after.md](https://github.com/user-attachments/files/31615394/after.md)
With PR changes: [pr.md](https://github.com/user-attachments/files/31615396/pr.md)
